### PR TITLE
Fix formatting of timestamp on streamed market prices

### DIFF
--- a/src/lightstreamer/LightstreamerAPI.ts
+++ b/src/lightstreamer/LightstreamerAPI.ts
@@ -78,8 +78,8 @@ export class LightstreamerAPI {
             bid: parseFloat(item.getValue(ChartFields.BID_OPEN)),
             lastTraded: parseFloat(item.getValue(ChartFields.LTP_OPEN)),
           },
-          snapshotTime: dt.toFormat('yyyy/LL/dd hh:mm:ss'),
-          snapshotTimeUTC: dt.toFormat("yyyy-LL-dd'T'hh:mm:ss"),
+          snapshotTime: dt.toFormat('yyyy/LL/dd HH:mm:ss'),
+          snapshotTimeUTC: dt.toFormat("yyyy-LL-dd'T'HH:mm:ss"),
         };
 
         onCandleUpdate(epic, candle);


### PR DESCRIPTION
Streamed price data is returning the wrong snapshotTime. For example 10:22pm would return a `10:22:00` rather than `22:22:00`