### PR TITLE
Pin Lighstreamer version to 8.0.5 as per IG docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^16.11.45",
     "axios": "^1.4.0",
     "axios-retry": "3.1.9",
-    "lightstreamer-client-node": "8.0.5",
+    "lightstreamer-client-node": "~8.0.5",
     "luxon": "^3.4.0"
   },
   "description": "IG Trading API for Node.js, written in TypeScript.",
@@ -93,5 +93,5 @@
     "test:dev": "nyc --nycrc-path=nyc.config.json jasmine --config=jasmine.json",
     "test:types": "yarn lint:types"
   },
-  "version": "0.13.6"
+  "version": "0.13.5"
 }

--- a/package.json
+++ b/package.json
@@ -93,5 +93,5 @@
     "test:dev": "nyc --nycrc-path=nyc.config.json jasmine --config=jasmine.json",
     "test:types": "yarn lint:types"
   },
-  "version": "0.13.5"
+  "version": "0.13.6"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^16.11.45",
     "axios": "^1.4.0",
     "axios-retry": "3.1.9",
-    "lightstreamer-client-node": "^9.0.0",
+    "lightstreamer-client-node": "8.0.5",
     "luxon": "^3.4.0"
   },
   "description": "IG Trading API for Node.js, written in TypeScript.",


### PR DESCRIPTION
I noticed that the Lightstreamer connection would return an error an immediately disconnect
`65: Unsupported protocol version: 2.5.0`

This error indicates a mismatch between client and server versions.
IG specifies the supported version here https://labs.ig.com/lightstreamer-downloads
![image](https://github.com/bennycode/ig-trading-api/assets/7934581/92accc0f-9d42-440d-8d03-8709a9f151e6)

For future work, the streaming API could be enhanced by automatically adding an error handling listener to the streaming connection.  Right now the user needs to do this manually so when there is an error with the stream the user doesn't know about it, just that the stream doesn't work.